### PR TITLE
Feature/simpler

### DIFF
--- a/precepte-core/src/main/scala/Precepte.scala
+++ b/precepte-core/src/main/scala/Precepte.scala
@@ -6,6 +6,7 @@ import scalaz.{ Bind, Monad, MonadPlus, Applicative, Functor, \/, \/-, -\/, Inde
 import scalaz.syntax.monad._
 
 class TaggingContext[T <: Tags, S <: PState[T], F[_]] {
+  
   sealed trait Precepte[A] {
     self =>
 

--- a/precepte-core/src/main/scala/adts.scala
+++ b/precepte-core/src/main/scala/adts.scala
@@ -59,21 +59,25 @@ object Tags {
 }
 
 
-/** The typed environment in which an event happens */
-trait Env
-case class BaseEnv(host: Tags.Host, environment: Tags.Environment, version: Tags.Version) extends Env
 
 /** The state gathering all data concerning current execution context */
 trait PState[T <: Tags]
 
 
+/** A hidden State Monad */
 trait PStatable[T <: Tags, S <: PState[T]] {
   def run(s: S, id: CId, tags: T): S
 }
 
+
+/** The typed environment in which an event happens */
+trait Env
+case class BaseEnv(host: Tags.Host, environment: Tags.Environment, version: Tags.Version) extends Env
+
 case class PStateBase[E <: Env, T <: Tags, C](span: Span, env: E, path: Call.Path[T], value: C) extends PState[T]
 
 object PStateBase {
+  
   implicit def pstatable[E <: Env, T <: Tags, C] = new PStatable[T, PStateBase[E, T, C]] {
     def run(s: PStateBase[E, T, C], id: CId, tags: T): PStateBase[E, T, C] = s.copy(path = s.path :+ Call(id, tags))
   }
@@ -92,7 +96,6 @@ sealed trait Graph[T <: Tags, S <: PState[T], G <: Graph[T, S, G]] {
     addChildren(Vector(c))
 }
 
-// case class GraphNode[T <: Tags, C](id: CId, value: C, tags: T, children: Vector[GraphNode[T, C]]) extends Graph[T, C, GraphNode[T, C]] {
 case class GraphNode[T <: Tags, S <: PState[T]](id: CId, value: S, tags: T, children: Vector[GraphNode[T, S]]) extends Graph[T, S, GraphNode[T, S]] {
   def addChildren(cs: Vector[GraphNode[T, S]]): GraphNode[T, S] =
     this.copy(children = children ++ cs)

--- a/precepte-core/src/main/scala/adts.scala
+++ b/precepte-core/src/main/scala/adts.scala
@@ -64,22 +64,45 @@ trait Env
 case class BaseEnv(host: Tags.Host, environment: Tags.Environment, version: Tags.Version) extends Env
 
 /** The state gathering all data concerning current execution context */
-case class State[E <: Env, T <: Tags, C](span: Span, env: E, path: Call.Path[T], value: C)
+trait PState[T <: Tags]
+
+
+trait PStatable[T <: Tags, S <: PState[T]] {
+  def run(s: S, id: CId, tags: T): S
+}
+
+case class PStateBase[E <: Env, T <: Tags, C](span: Span, env: E, path: Call.Path[T], value: C) extends PState[T]
+
+object PStateBase {
+  implicit def pstatable[E <: Env, T <: Tags, C] = new PStatable[T, PStateBase[E, T, C]] {
+    def run(s: PStateBase[E, T, C], id: CId, tags: T): PStateBase[E, T, C] = s.copy(path = s.path :+ Call(id, tags))
+  }
+
+  implicit def rootable[E <: Env, T <: Tags, C] = new Rootable[T, PStateBase[E, T, C]] {
+    def toRoot(s: PStateBase[E, T, C]): Root[T, PStateBase[E, T, C]] = Root[T, PStateBase[E, T, C]](s.span, Vector.empty)
+  }
+}
 
 /** The graph of execution of a Call */
-sealed trait Graph[T <: Tags, C, G <: Graph[T, C, G]] {
-  val children: Vector[GraphNode[T, C]]
-  def addChildren(cs: Vector[GraphNode[T, C]]): G
-  def addChild(c: GraphNode[T, C]): G =
+// sealed trait Graph[T <: Tags, C, G <: Graph[T, C, G]] {
+sealed trait Graph[T <: Tags, S <: PState[T], G <: Graph[T, S, G]] {
+  val children: Vector[GraphNode[T, S]]
+  def addChildren(cs: Vector[GraphNode[T, S]]): G
+  def addChild(c: GraphNode[T, S]): G =
     addChildren(Vector(c))
 }
 
-case class GraphNode[T <: Tags, C](id: CId, value: C, tags: T, children: Vector[GraphNode[T, C]]) extends Graph[T, C, GraphNode[T, C]] {
-  def addChildren(cs: Vector[GraphNode[T, C]]): GraphNode[T, C] =
+// case class GraphNode[T <: Tags, C](id: CId, value: C, tags: T, children: Vector[GraphNode[T, C]]) extends Graph[T, C, GraphNode[T, C]] {
+case class GraphNode[T <: Tags, S <: PState[T]](id: CId, value: S, tags: T, children: Vector[GraphNode[T, S]]) extends Graph[T, S, GraphNode[T, S]] {
+  def addChildren(cs: Vector[GraphNode[T, S]]): GraphNode[T, S] =
     this.copy(children = children ++ cs)
 }
 
-case class Root[T <: Tags, C](span: Span, children: Vector[GraphNode[T, C]]) extends Graph[T, C, Root[T, C]] {
-  def addChildren(cs: Vector[GraphNode[T, C]]): Root[T, C] =
+case class Root[T <: Tags, S <: PState[T]](span: Span, children: Vector[GraphNode[T, S]]) extends Graph[T, S, Root[T, S]] {
+  def addChildren(cs: Vector[GraphNode[T, S]]): Root[T, S] =
     this.copy(children = children ++ cs)
+}
+
+trait Rootable[T <: Tags, S <: PState[T]] {
+  def toRoot(s: S): Root[T, S]
 }

--- a/precepte-core/src/main/scala/package.scala
+++ b/precepte-core/src/main/scala/package.scala
@@ -11,6 +11,6 @@ package object precepte {
     def apply[C](span: Span, env: BaseEnv, path: Call.Path[BaseTags], value: C): PST0[C] = PStateBase(span, env, path, value)
   }
 
-  type TCTX0[F[_], C] = TaggingContext[BaseTags, PST0[C], F]
+  type PCTX0[F[_], C] = TaggingContext[BaseTags, PST0[C], F]
 
 }

--- a/precepte-core/src/main/scala/package.scala
+++ b/precepte-core/src/main/scala/package.scala
@@ -1,0 +1,16 @@
+package com.mfglabs
+
+import scala.language.higherKinds
+
+
+package object precepte {
+
+  type PST0[C] = PStateBase[BaseEnv, BaseTags, C]
+
+  object PST0 {
+    def apply[C](span: Span, env: BaseEnv, path: Call.Path[BaseTags], value: C): PST0[C] = PStateBase(span, env, path, value)
+  }
+
+  type TCTX0[F[_], C] = TaggingContext[BaseTags, PST0[C], F]
+
+}

--- a/precepte-core/src/test/scala/PrecepteSpec.scala
+++ b/precepte-core/src/test/scala/PrecepteSpec.scala
@@ -23,8 +23,8 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
   import scalaz.EitherT
 
   // val taggingContext = new TaggingContext[BaseEnv, BaseTags, Unit, Future]
-  type STATE[C] = PStateBase[BaseEnv, BaseTags, C]
-  val taggingContext = new TaggingContext[BaseTags, STATE[Unit], Future]
+  type PST[C] = PStateBase[BaseEnv, BaseTags, C]
+  val taggingContext = new TaggingContext[BaseTags, PST[Unit], Future]
   import taggingContext._
   import Precepte._
 
@@ -50,8 +50,8 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     }
   }
 
-  def toStates[C](g: Root[BaseTags, STATE[C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
-    def go(g: GraphNode[BaseTags, STATE[C]], span: Span, path: Call.Path[BaseTags], states: Seq[PStateBase[BaseEnv, BaseTags, C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
+  def toStates[C](g: Root[BaseTags, PST[C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
+    def go(g: GraphNode[BaseTags, PST[C]], span: Span, path: Call.Path[BaseTags], states: Seq[PStateBase[BaseEnv, BaseTags, C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
       val GraphNode(id, value, tags, cs) = g
       val p = path :+ Call(id, tags)
       val st = PStateBase[BaseEnv, BaseTags, C](span, env, p, value.value)
@@ -80,12 +80,12 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     result0 should ===(1)
 
     println("-- graph0 --")
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graph0)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph0)
     println("----")
 
     val (graphm, _) = Precepte(tags("graphm0"))(Precepte(tags("graphm"))(f1)).run(nostate).futureValue
     println("-- graphm --")
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graphm)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graphm)
     println("----")
 
     val res =
@@ -98,12 +98,12 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     result should ===("foo 1")
 
     println("-- graph --")
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graph)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph)
     println("----")
 
     val (graph1, result1) = Precepte(tags("trivial.anon"))(res).run(nostate).futureValue
     println("-- graph1 --")
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graph1)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph1)
     println("----")
 
     val res2 =
@@ -114,7 +114,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
 
     val (graph2, result2) = res2.run(nostate, (1 to 30).map(i => CId(i.toString)).toStream).futureValue
     println("-- graph2 --")
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graph2)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph2)
     println("----")
   }
 
@@ -220,7 +220,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
 
     val (graph, rr) = res3.run.run(nostate).futureValue
     rr should ===(error)
-    p[Unit, STATE[Unit], Root[BaseTags, STATE[Unit]]](graph)
+    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph)
   }
 
   it should "pass context" in {

--- a/precepte-core/src/test/scala/PrecepteSpec.scala
+++ b/precepte-core/src/test/scala/PrecepteSpec.scala
@@ -22,7 +22,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
   import scalaz.syntax.monad._
   import scalaz.EitherT
 
-  val taggingContext = new TCTX0[Future, Unit]
+  val taggingContext = new PCTX0[Future, Unit]
   import taggingContext._
   import Precepte._
 

--- a/precepte-core/src/test/scala/PrecepteSpec.scala
+++ b/precepte-core/src/test/scala/PrecepteSpec.scala
@@ -22,9 +22,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
   import scalaz.syntax.monad._
   import scalaz.EitherT
 
-  // val taggingContext = new TaggingContext[BaseEnv, BaseTags, Unit, Future]
-  type PST[C] = PStateBase[BaseEnv, BaseTags, C]
-  val taggingContext = new TaggingContext[BaseTags, PST[Unit], Future]
+  val taggingContext = new TCTX0[Future, Unit]
   import taggingContext._
   import Precepte._
 
@@ -50,8 +48,8 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     }
   }
 
-  def toStates[C](g: Root[BaseTags, PST[C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
-    def go(g: GraphNode[BaseTags, PST[C]], span: Span, path: Call.Path[BaseTags], states: Seq[PStateBase[BaseEnv, BaseTags, C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
+  def toStates[C](g: Root[BaseTags, PST0[C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
+    def go(g: GraphNode[BaseTags, PST0[C]], span: Span, path: Call.Path[BaseTags], states: Seq[PStateBase[BaseEnv, BaseTags, C]]): Seq[PStateBase[BaseEnv, BaseTags, C]] = {
       val GraphNode(id, value, tags, cs) = g
       val p = path :+ Call(id, tags)
       val st = PStateBase[BaseEnv, BaseTags, C](span, env, p, value.value)
@@ -80,12 +78,12 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     result0 should ===(1)
 
     println("-- graph0 --")
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph0)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graph0)
     println("----")
 
     val (graphm, _) = Precepte(tags("graphm0"))(Precepte(tags("graphm"))(f1)).run(nostate).futureValue
     println("-- graphm --")
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graphm)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graphm)
     println("----")
 
     val res =
@@ -98,12 +96,12 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
     result should ===("foo 1")
 
     println("-- graph --")
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graph)
     println("----")
 
     val (graph1, result1) = Precepte(tags("trivial.anon"))(res).run(nostate).futureValue
     println("-- graph1 --")
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph1)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graph1)
     println("----")
 
     val res2 =
@@ -114,7 +112,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
 
     val (graph2, result2) = res2.run(nostate, (1 to 30).map(i => CId(i.toString)).toStream).futureValue
     println("-- graph2 --")
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph2)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graph2)
     println("----")
   }
 
@@ -220,7 +218,7 @@ class PrecepteSpec extends FlatSpec with ScalaFutures {
 
     val (graph, rr) = res3.run.run(nostate).futureValue
     rr should ===(error)
-    p[Unit, PST[Unit], Root[BaseTags, PST[Unit]]](graph)
+    p[Unit, PST0[Unit], Root[BaseTags, PST0[Unit]]](graph)
   }
 
   it should "pass context" in {

--- a/precepte-influx/src/main/scala/Influx.scala
+++ b/precepte-influx/src/main/scala/Influx.scala
@@ -11,7 +11,7 @@ import scala.language.postfixOps
 import akka.actor.{ Actor, Props, ActorSystem }
 import Call._
 
-case class Influx[TC <: TaggingContext[BaseEnv, BaseTags, C, Future], C](ctx: TC, influxdbURL: URL, env: BaseEnv, system: ActorSystem)(implicit ex: ExecutionContext) {
+case class Influx[C, TC <: TaggingContext[BaseTags, PStateBase[BaseEnv, BaseTags, C], Future]](ctx: TC, influxdbURL: URL, env: BaseEnv, system: ActorSystem)(implicit ex: ExecutionContext) {
 
   private val builder = new com.ning.http.client.AsyncHttpClientConfig.Builder()
   private val WS = new play.api.libs.ws.ning.NingWSClient(builder.build())
@@ -71,13 +71,13 @@ case class Influx[TC <: TaggingContext[BaseEnv, BaseTags, C, Future], C](ctx: TC
     }
   }
 
-  def Timed[A](category: Tags.Category)(callee: Tags.Callee)(f: State[BaseEnv, BaseTags, C] => Future[A])(implicit fu: scalaz.Functor[Future]): TC#Precepte[A] =
-    ctx.Precepte(BaseTags(callee, category)){ (c: State[BaseEnv, BaseTags, C]) =>
+  def Timed[A](category: Tags.Category)(callee: Tags.Callee)(f: PStateBase[BaseEnv, BaseTags, C] => Future[A])(implicit fu: scalaz.Functor[Future]): TC#Precepte[A] =
+    ctx.Precepte(BaseTags(callee, category)){ (c: PStateBase[BaseEnv, BaseTags, C]) =>
       Timer(c.span, c.path).timed(f(c))
     }
 
   def TimedM[A](category: Tags.Category)(callee: Tags.Callee)(f: TC#Precepte[A])(implicit mo: scalaz.Monad[Future]): TC#Precepte[A] =
-    ctx.Precepte(BaseTags(callee, category)){ (c: State[BaseEnv, BaseTags, C]) =>
+    ctx.Precepte(BaseTags(callee, category)){ (c: PStateBase[BaseEnv, BaseTags, C]) =>
       Timer(c.span, c.path).timed(f.eval(c))
     }
 

--- a/precepte-sample/app/Monitoring.scala
+++ b/precepte-sample/app/Monitoring.scala
@@ -13,8 +13,8 @@ object Monitoring {
 
 	import play.api.libs.json._
 
-  object PreContext extends TaggingContext[BaseEnv, BaseTags, Unit, Future]
-  type ST = State[BaseEnv, BaseTags, Unit]
+  object PreContext extends TaggingContext[BaseTags, PStateBase[BaseEnv, BaseTags, Unit], Future]
+  type ST = PStateBase[BaseEnv, BaseTags, Unit]
 
 	val env = BaseEnv(
 		Tags.Host(java.net.InetAddress.getLocalHost().getHostName()),
@@ -43,7 +43,7 @@ object Monitoring {
 	}
 
 	object MonitoringContext {
-		def apply[C](st: State[BaseEnv, BaseTags, C]): MonitoringContext = MonitoringContext(st.span, st.path)
+		def apply[C](st: PStateBase[BaseEnv, BaseTags, C]): MonitoringContext = MonitoringContext(st.span, st.path)
 	}
 }
 

--- a/precepte-sample/test/ModelSpec.scala
+++ b/precepte-sample/test/ModelSpec.scala
@@ -21,7 +21,7 @@ class ModelSpec extends PlaySpecification {
 
   val env = BaseEnv(Tags.Host("localhost"), Tags.Environment.Dev, Tags.Version("1.0"))
   private def tags(n: String) = BaseTags(Tags.Callee(n), Tags.Category.Database)
-  def nostate = State[BaseEnv, BaseTags, Unit](Span.gen, env, Vector.empty, ())
+  def nostate = PST0(Span.gen, env, Vector.empty, ())
 
   "Computer model" should {
 


### PR DESCRIPTION
> `Env` et `C` me semblaient très artificiels au niveau du `Precepte` et uniquement liés à la structure très spécifique du `State` qu'on a choisi et le modèle me semblait trop spécifique, trop fragile.

En réfléchissant, j'ai découvert que:
- `Tags` est l'élément important pour le `Precepte` au niveau du `Step`
- Dans la ligne présente dans `eval` et `run`:
```
val state0 = state.copy(path = state.path :+ Call(ids.head, tags))
```
`State` ressemble bcp à une vraie `StateMonad` à qui on passe un `CId` et des `Tags` et qui renvoie un nouveau `State`: `(State, CId, Tags) => State` 

- `State` en tant que type générique utilisé dans `Precepte` n'a pas besoin de `Env` ni `C` mais seulement de `Tags` qui permet de contextualiser un `Step`. Pou les autres structures, on n'en a pas besoin

Mon idée maintenant:
- Créer un `PState[T <: Tags]` plus générique utilisé dans `Precepte` qui n'amène plus de type superficiel dans `Precepte` qui ne comprend que `Tags` et `CId`

- `PStateBase[T <: Tags, E <: Env, C]` devient une implémentation particulière fournissant un Environnement et une valeur `C`

- Remplacer `C` dans `Graph` par `PState` car ça ne change pas le sens

- Créer 2 typeclasses:
    - `PStatable`: une simili `StateMonad` capable de faire `(PState[T], CId, T) => PState[T]` pour les fonctions `eval` et `run` et qui doit être implémentée pour chaque type de `PState[T]`
    - `Rootable`: permet de construire un `Root` vide à partir d'un `PState[T]`

