### PR TITLE
Add resolvers for play 2.3.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ lazy val commonSettings =  Seq(
   , resolvers ++= Seq(
       "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
     , "Oncue Bintray Repo" at "http://dl.bintray.com/oncue/releases"
+    , "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"  //for play 2.3.9
+    , "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots" //for play 2.3.9
   )
   , logLevel in update := Level.Warn
 )


### PR DESCRIPTION
 this commit fixes #3

when building on a clean machine i got the following unresolved dependencies:
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] :: UNRESOLVED DEPENDENCIES ::
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] :: com.typesafe.netty#netty-http-pipelining;1.1.2: not found
[warn] ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn] Note: Unresolved dependencies path:
[warn] com.typesafe.netty:netty-http-pipelining:1.1.2
[warn] +- com.typesafe.play:play_2.11:2.3.9
[warn] +- com.typesafe.play:play-ws_2.11:2.3.9 (/home/vagrant/my_projects/precepte/build.sbt#L85)
[warn] +- com.mfglabs:precepte-influx_2.11:0.1.4-SNAPSHOT
sbt.ResolveException: unresolved dependency: com.typesafe.netty#netty-http-pipelining;1.1.2: not found

these were due to some changes caused by typesafe moving stuff around in repos: see discussion here: https://github.com/typesafehub/netty-http-pipelining/issues/13