### PR TITLE
Less verbose Logback output

### DIFF
--- a/precepte-logback/src/main/scala/Logback.scala
+++ b/precepte-logback/src/main/scala/Logback.scala
@@ -30,7 +30,6 @@ case class Logback(env: BaseEnv, loggerName: String) {
   import ch.qos.logback.classic.LoggerContext
 
   val logger = LoggerFactory.getLogger(loggerName)
-  StatusPrinter.print((LoggerFactory.getILoggerFactory).asInstanceOf[LoggerContext])
 
   val sep = "/"
 

--- a/precepte-sample/conf/application-logger.xml
+++ b/precepte-sample/conf/application-logger.xml
@@ -18,8 +18,6 @@
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />
-    <appender-ref ref="FILE" />
-    <appender-ref ref="LE" />
   </root>
 
 </configuration>


### PR DESCRIPTION
If warning or errors occur during the parsing of the configuration file, Logback will automatically print its internal status messages on the console.

Instead of invoking `StatusPrinter` programmatically from your code, you can instruct the configuration file to dump status data, even in the absence of errors. To achieve this, you need to set the `debug` attribute of the configuration element, i.e. the top-most element in the configuration file.

```xml
<configuration debug="true"> 

  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
  </appender>

  <root level="debug">
    <appender-ref ref="STDOUT" />
  </root>
</configuration>
```