### PR TITLE
Add `retentionPolicy` parameter to `Influx` client

### DIFF
--- a/documentation/main.md
+++ b/documentation/main.md
@@ -385,19 +385,20 @@ val demo =
 ```
 
 Now we have created the program but we've not executed it yet.
-All we have to do to push metrics into an [influxdb](https://influxdb.com/) instance is configure the influx client, and "inject" it into the execution of our program.
+All we have to do to push metrics into an [influxdb](https://influxdb.com/) instance is configure the influx client, and "inject" it into the execution of our program. Since InfluxDB v1.0, the automatically created retention policy (when database is created) is named `autogen`. In previous versions, its name was `default`. In the following, the default `autogen` retention policy is used.
 
 ```scala
 val influx = Influx[Unit](
     new java.net.URL("http://localhost:8086"),
       "root",
       "root",
-      "precepte_demo"
+      "precepte_demo",
+      "autogen"
     )
 val monitoredDemo = demo.mapSuspension(influx.monitor)
 ```
 
-now if we execute the code, metrics are automatically pushed to Influxdb.
+Now if we execute the code, metrics are automatically pushed to InfluxDB.
 
 ```scala
 val result =

--- a/precepte-influx/src/main/scala/Influx.scala
+++ b/precepte-influx/src/main/scala/Influx.scala
@@ -33,7 +33,8 @@ case class Influx[C : MetaSemigroup](
   influxdbURL: URL,
   user: String,
   password: String,
-  dbName: String
+  dbName: String,
+  retentionPolicy: String
 )(implicit ex: ExecutionContext) {
 
   import scala.util.{ Try, Failure, Success }
@@ -87,7 +88,7 @@ case class Influx[C : MetaSemigroup](
             f.map { r =>
               val t1 = System.nanoTime()
               val serie = toSerie(t0, t1, System.currentTimeMillis(), st)
-              in.write(dbName, "default", serie)
+              in.write(dbName, retentionPolicy, serie)
               r
             }
           }

--- a/precepte-sample/app/Monitoring.scala
+++ b/precepte-sample/app/Monitoring.scala
@@ -28,7 +28,8 @@ object Monitoring {
     new java.net.URL("http://localhost:8086"),
       "root",
       "root",
-      "precepte_sample"
+      "precepte_sample",
+      "autogen"
     )
 
   lazy val logback = Logback(env, "application")


### PR DESCRIPTION
Add `retentionPolicy` parameter to `Influx` client, due to default retention policy name change since v1.0 (`autogen` instead of `default`).

See:
- https://docs.influxdata.com/influxdb/v1.0/administration/config#retention-autocreate-true
- https://github.com/influxdata/influxdb/issues/3733
