### PR TITLE
feat: use openjdk8 instead of oraclejdk8 on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
    - 2.11.12
    - 2.12.6
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
   - "$HOME/.ivy2/cache"


### PR DESCRIPTION
openjdk8 is no longer available on Xenial.
See https://github.com/travis-ci/travis-ci/issues/10290