### PR TITLE
Release Candidate 2 of version 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings =  Seq(
     organization := "com.mfglabs"
-  , version := "0.5.0-rc1"
+  , version := "0.5.0-rc2"
   , isSnapshot := false
   , crossScalaVersions := Seq("2.12.8")
   , resolvers ++= Seq(

--- a/precepte-core-scalaz/src/main/scala/package.scala
+++ b/precepte-core-scalaz/src/main/scala/package.scala
@@ -18,20 +18,19 @@ package com.mfglabs
 package precepte
 
 import scala.concurrent.Future
-
 import scalaz.{
-  Monad,
+  -\/,
   Applicative,
+  EitherT,
   Functor,
-  Unapply,
+  ListT,
+  Monad,
+  OptionT,
   Semigroup,
-  ~>,
+  Unapply,
   \/,
   \/-,
-  -\/,
-  EitherT,
-  OptionT,
-  ListT
+  ~>
 }
 import scalaz.Isomorphism.<~>
 

--- a/precepte-core/src/main/scala/Measure.scala
+++ b/precepte-core/src/main/scala/Measure.scala
@@ -1,0 +1,105 @@
+package com.mfglabs
+package precepte
+
+import shapeless.tag
+import shapeless.tag.@@
+
+import scala.concurrent.duration._
+
+/** A measure is an instrumentation that generate a metric for some
+  * computation {{{subjectToMeasure}}} and send generated metrics to
+  * a collection of consumers.
+  *
+  * @tparam F a functor (generally a monad)
+  * @tparam A the type of the metric generated
+  */
+trait Measure[F[_], A] { self =>
+
+  /** Compute a metric of type [[A]] from [[subjectToMesure]]. Then
+    * send this metric to all consumers. Finally returns a {{{F[B]}}}
+    * that must be observationally equivalent to [[subjectToMesure]].
+    *
+    * The measure SHOULD NEVER halter the behavior: the only effect
+    * introduced by the measure should be sending the metrics.
+    *
+    * @param subjectToMesure
+    * @param consumers
+    * @tparam B
+    * @return
+    */
+  def measure[B](subjectToMesure: F[B])(consumers: Vector[A => F[Unit]]): F[B]
+
+  @inline final def withConsumers(consumers: Vector[A => F[Unit]]): F ~~> F =
+    new (F ~~> F) {
+      def apply[B](fb: F[B]): F[B] = self.measure(fb)(consumers)
+    }
+
+  @inline final def withConsumer(consumers: A => F[Unit]): F ~~> F =
+    withConsumers(Vector(consumers))
+}
+
+object Measure {
+
+  /** Represents
+    *
+    * @param startTime start time of computation execution
+    * @param endTime end time of computation execution
+    * @param now time when the measure was created
+    * @param exception is Some(e) if the computation failed, raising exception e.
+    *                  or None if the computation succeeded.
+    * @param state the precepte state of the computation
+    * @tparam T precepte Tags
+    * @tparam M precepte Managed state
+    * @tparam U precepte Unmanaged state
+    */
+  final case class TimeMeasurement[T, M, U](
+      startTime: Long @@ NANOSECONDS.type,
+      endTime: Long @@ NANOSECONDS.type,
+      now: Long @@ MILLISECONDS.type,
+      exception: Option[Throwable],
+      state: PState[T, M, U]
+  )
+
+  final class TimeMeasure[T, M, U, F[_]]
+      extends Measure[Precepte[T, M, U, F, ?], TimeMeasurement[T, M, U]] {
+
+    /** Compute a metric of type [[A]] from [[subjectToMesure]]. Then
+      * send this metric to all consumers. Finally returns a {{{F[B]}}}
+      * that must be observationally equivalent to [[subjectToMesure]].
+      *
+      * The measure SHOULD NEVER halter the behavior: the only effect
+      * introduced by the measure should be sending the metrics.
+      *
+      * @param subjectToMesure
+      * @param consumers
+      * @tparam B
+      * @return
+      */
+    def measure[B](subjectToMesure: Precepte[T, M, U, F, B])(
+        consumers: Vector[
+          TimeMeasurement[T, M, U] => Precepte[T, M, U, F, Unit]])
+      : Precepte[T, M, U, F, B] = {
+
+      object P extends Precepte.API[T, M, U, F]
+
+      for {
+        state <- P.get
+        startTime <- P.delay(tag[NANOSECONDS.type](System.nanoTime()))
+        result <- subjectToMesure.attempt
+        endTime <- P.delay(tag[NANOSECONDS.type](System.nanoTime()))
+        now <- P.delay(tag[MILLISECONDS.type](System.currentTimeMillis()))
+        mes = TimeMeasurement(startTime,
+                              endTime,
+                              now,
+                              result.fold(Some(_), _ => None),
+                              state)
+        _ <- consumers.foldLeft(P.pure(())) {
+          case (acc, consumer) =>
+            // A consumer failing should not make the whole computation failing too!
+            P.map2(acc, consumer(mes).recoverWithValue(()))((_, _) => ())
+        }
+        r <- Precepte.fromTry(result)
+      } yield r
+    }
+  }
+}

--- a/precepte-core/src/main/scala/Precepte.scala
+++ b/precepte-core/src/main/scala/Precepte.scala
@@ -97,6 +97,12 @@ sealed trait Precepte[T, M, U, F[_], A] {
 
   final type precepte[A0] = Precepte[T, M, U, F, A0]
 
+  @inline final def subStep(tags: T,
+                            leaf: Boolean = true,
+                            nats: Vector[SubStepInstrumentation[T, M, U, F]] =
+                              Vector.empty): precepte[A] =
+    Precepte.subStep(tags, leaf, nats)(self)
+
   @inline final def flatMap[B](f: A => precepte[B]): precepte[B] =
     Precepte.flatMap[T, M, U, F, A, B](this)(f)
 
@@ -105,6 +111,9 @@ sealed trait Precepte[T, M, U, F[_], A] {
 
   @inline final def ap[B](f: precepte[A => B]): precepte[B] =
     Precepte.ap(this)(f)
+
+  @inline final def recoverWithValue(value: A): precepte[A] =
+    Precepte.catchError(this)(_ => Precepte.pure(value))
 
   @inline final def recoverWith(
       handler: Throwable => precepte[A]): precepte[A] =

--- a/precepte-logback/src/main/scala/Logback.scala
+++ b/precepte-logback/src/main/scala/Logback.scala
@@ -49,6 +49,8 @@ final class Logback(val env: BaseEnv, val loggerName: String) {
       ).asJava
     }
 
+    val underlyingLogger: org.slf4j.Logger = logger
+
     def debug(message: => String, params: Seq[(String, String)] = Nil): Unit =
       logger.debug(appendEntries(p(params)), message)
     def info(message: => String, params: Seq[(String, String)] = Nil): Unit =


### PR DESCRIPTION
- Precepte-Play Actions can tranform precepte computation (for
  example to add telemetry)
- ApplicationInsight and Influx Metrics consumer support custom
  error handlers